### PR TITLE
🔐 Security: Disable inbound calls by default

### DIFF
--- a/scripts/webhook-server.py
+++ b/scripts/webhook-server.py
@@ -461,8 +461,8 @@ async def handle_webhook(request: Request, background_tasks: BackgroundTasks):
     """
     body = await request.body()
     
-    # DEBUG: Log raw webhook body
-    logger.info(f"[DEBUG] Raw webhook body: {body[:500] if body else 'empty'}")
+    # Log raw webhook body for debugging
+    logger.debug(f"Raw webhook body: {body[:500] if body else 'empty'}")
     
     # Check if this is a Twilio webhook by looking for CallStatus or Twilio signature
     twilio_signature = request.headers.get("X-Twilio-Signature")


### PR DESCRIPTION
## Summary

Fixes #28 - Inbound calls had no authentication, allowing anyone who knows the SIP URI to call in and interact with the agent.

## Changes

- Add `ALLOW_INBOUND_CALLS` config flag (defaults to `false`)
- Detect true inbound calls vs outbound callbacks via `matched_call_id`
- Reject inbound calls with SIP 480 (Temporarily Unavailable) when disabled
- Clear warning log for rejected calls
- Move recording start to after acceptance (no point recording rejected calls)

## Security Impact

- **Before**: Any caller could reach the agent
- **After**: Only outbound calls (matched by destination number or time window) are accepted

## Testing

1. Start server with default config
2. Attempt inbound call → should be rejected with log warning
3. Make outbound call → should work normally (matched via `active_calls`)
4. Set `ALLOW_INBOUND_CALLS=true` → inbound calls work again

## Configuration

```bash
# Keep inbound calls disabled (default - secure)
ALLOW_INBOUND_CALLS=false

# Enable inbound calls (if needed)
ALLOW_INBOUND_CALLS=true
```