### PR TITLE
feat: Call Observability System

### DIFF
--- a/channel-plugin/src/adapters/session-bridge.ts
+++ b/channel-plugin/src/adapters/session-bridge.ts
@@ -123,6 +123,11 @@ export class VoiceSessionBridge {
         this.log.info(`[voice-bridge] GET /health - Health check`);
         this.log.info(`[voice-bridge] GET /zombie-calls - List zombie/stale calls`);
         this.log.info(`[voice-bridge] POST /cleanup-stale-calls - Clean up zombie calls`);
+        this.log.info(`[voice-bridge] GET /metrics - Prometheus metrics`);
+        this.log.info(`[voice-bridge] GET /metrics/dashboard - Dashboard data`);
+        this.log.info(`[voice-bridge] GET /metrics/export - Export data (CSV/JSON)`);
+        this.log.info(`[voice-bridge] GET /metrics/health - Health check`);
+        this.log.info(`[voice-bridge] GET /metrics/failures - Recent failures`);
         resolve();
       });
     });
@@ -248,6 +253,120 @@ export class VoiceSessionBridge {
             details: err instanceof Error ? err.message : String(err),
           })
         );
+      }
+      return;
+    }
+
+    // ==================== METRICS ENDPOINTS ====================
+
+    // Prometheus-style metrics (GET /metrics)
+    if (url.pathname === "/metrics" && req.method === "GET") {
+      try {
+        const metrics = await this.getPrometheusMetrics();
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.statusCode = 200;
+        res.end(metrics);
+      } catch (err) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "Failed to get metrics" }));
+      }
+      return;
+    }
+
+    // Dashboard data (GET /metrics/dashboard)
+    if (url.pathname === "/metrics/dashboard" && req.method === "GET") {
+      try {
+        const dashboard = await this.getDashboardMetrics();
+        res.statusCode = 200;
+        res.end(JSON.stringify(dashboard));
+      } catch (err) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "Failed to get dashboard data" }));
+      }
+      return;
+    }
+
+    // Export data (GET /metrics/export)
+    if (url.pathname === "/metrics/export" && req.method === "GET") {
+      try {
+        const format = url.searchParams.get("format") || "json";
+        const daysParam = url.searchParams.get("days");
+        const days = daysParam ? parseInt(daysParam, 10) : 30;
+        
+        const data = await this.exportMetrics(format, days);
+        
+        if (format === "csv") {
+          res.setHeader("Content-Type", "text/csv; charset=utf-8");
+          res.setHeader("Content-Disposition", `attachment; filename="calls-export-${new Date().toISOString().split('T')[0]}.csv"`);
+        } else {
+          res.setHeader("Content-Type", "application/json");
+        }
+        res.statusCode = 200;
+        res.end(data);
+      } catch (err) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "Export failed" }));
+      }
+      return;
+    }
+
+    // Health check with metrics (GET /metrics/health)
+    if (url.pathname === "/metrics/health" && req.method === "GET") {
+      try {
+        const health = await this.getHealthCheck();
+        res.statusCode = health.status === "healthy" ? 200 : 503;
+        res.end(JSON.stringify(health));
+      } catch (err) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ 
+          status: "error", 
+          error: "Health check failed" 
+        }));
+      }
+      return;
+    }
+
+    // Recent failures (GET /metrics/failures)
+    if (url.pathname === "/metrics/failures" && req.method === "GET") {
+      try {
+        const limitParam = url.searchParams.get("limit");
+        const limit = limitParam ? parseInt(limitParam, 10) : 10;
+        const failures = await this.getRecentFailures(limit);
+        res.statusCode = 200;
+        res.end(JSON.stringify({ failures, count: failures.length }));
+      } catch (err) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "Failed to get failures" }));
+      }
+      return;
+    }
+
+    // Hourly timeseries (GET /metrics/hourly)
+    if (url.pathname === "/metrics/hourly" && req.method === "GET") {
+      try {
+        const hoursParam = url.searchParams.get("hours");
+        const hours = hoursParam ? parseInt(hoursParam, 10) : 24;
+        const timeseries = await this.getHourlyTimeseries(hours);
+        res.statusCode = 200;
+        res.end(JSON.stringify({ timeseries, hours }));
+      } catch (err) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "Failed to get timeseries" }));
+      }
+      return;
+    }
+
+    // Daily timeseries (GET /metrics/daily)
+    if (url.pathname === "/metrics/daily" && req.method === "GET") {
+      try {
+        const daysParam = url.searchParams.get("days");
+        const days = daysParam ? parseInt(daysParam, 10) : 30;
+        const timeseries = await this.getDailyTimeseries(days);
+        res.statusCode = 200;
+        res.end(JSON.stringify({ timeseries, days }));
+      } catch (err) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "Failed to get timeseries" }));
       }
       return;
     }
@@ -603,6 +722,420 @@ export class VoiceSessionBridge {
         `[voice-bridge] Failed to get zombie calls: ${err instanceof Error ? err.message : String(err)}`
       );
       throw err;
+    }
+  }
+
+  // ==================== METRICS METHODS ====================
+
+  /**
+   * Get Prometheus-style metrics for monitoring integration.
+   */
+  async getPrometheusMetrics(): Promise<string> {
+    try {
+      const url = `${this.config.webhookServerUrl}/metrics/prometheus`;
+      this.log.debug(`[voice-bridge] Fetching Prometheus metrics from ${url}`);
+      const response = await fetch(url, { method: "GET" });
+      
+      if (response.ok) {
+        return await response.text();
+      }
+      
+      // Fallback: construct metrics from storage stats
+      return this.constructPrometheusMetrics();
+    } catch (err) {
+      this.log.warn(`[voice-bridge] Prometheus fetch failed, using fallback: ${err}`);
+      return this.constructPrometheusMetrics();
+    }
+  }
+
+  /**
+   * Construct Prometheus metrics from available data.
+   */
+  private async constructPrometheusMetrics(): Promise<string> {
+    try {
+      const statsUrl = `${this.config.webhookServerUrl}/storage/stats`;
+      const response = await fetch(statsUrl, { method: "GET" });
+      
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      
+      const stats = await response.json() as {
+        total_calls: number;
+        active_calls: number;
+        calls_with_audio: number;
+        calls_with_transcripts: number;
+        recordings_size_mb: number;
+      };
+      
+      const lines = [
+        "# HELP voice_calls_total Total number of calls",
+        "# TYPE voice_calls_total counter",
+        `voice_calls_total ${stats.total_calls}`,
+        "",
+        "# HELP voice_calls_active Currently active calls",
+        "# TYPE voice_calls_active gauge",
+        `voice_calls_active ${stats.active_calls}`,
+        "",
+        "# HELP voice_calls_with_transcript Calls with transcripts",
+        "# TYPE voice_calls_with_transcript counter",
+        `voice_calls_with_transcript ${stats.calls_with_transcripts}`,
+        "",
+        "# HELP voice_storage_size_mb Storage size in MB",
+        "# TYPE voice_storage_size_mb gauge",
+        `voice_storage_size_mb ${stats.recordings_size_mb?.toFixed(2) || 0}`,
+        "",
+        "# HELP voice_bridge_active_sessions Active bridge sessions",
+        "# TYPE voice_bridge_active_sessions gauge",
+        `voice_bridge_active_sessions ${callSessionMap.size}`,
+      ];
+      
+      return lines.join("\n") + "\n";
+    } catch (err) {
+      return `# Error fetching metrics: ${err}\n`;
+    }
+  }
+
+  /**
+   * Get dashboard metrics for visualization.
+   */
+  async getDashboardMetrics(): Promise<Record<string, unknown>> {
+    try {
+      const url = `${this.config.webhookServerUrl}/metrics/dashboard`;
+      this.log.debug(`[voice-bridge] Fetching dashboard metrics from ${url}`);
+      const response = await fetch(url, { method: "GET" });
+      
+      if (response.ok) {
+        return await response.json() as Record<string, unknown>;
+      }
+      
+      // Fallback: construct from available data
+      return this.constructDashboardMetrics();
+    } catch (err) {
+      this.log.warn(`[voice-bridge] Dashboard fetch failed, using fallback: ${err}`);
+      return this.constructDashboardMetrics();
+    }
+  }
+
+  /**
+   * Construct dashboard metrics from available data.
+   */
+  private async constructDashboardMetrics(): Promise<Record<string, unknown>> {
+    try {
+      const statsUrl = `${this.config.webhookServerUrl}/storage/stats`;
+      const historyUrl = `${this.config.webhookServerUrl}/history?limit=100`;
+      
+      const [statsResponse, historyResponse] = await Promise.all([
+        fetch(statsUrl),
+        fetch(historyUrl),
+      ]);
+      
+      const stats = statsResponse.ok 
+        ? await statsResponse.json() as Record<string, unknown>
+        : { total_calls: 0, active_calls: 0 };
+      
+      const calls = historyResponse.ok
+        ? await historyResponse.json() as Array<{
+            status: string;
+            duration_seconds: number | null;
+            call_type: string;
+            has_transcript: boolean;
+          }>
+        : [];
+      
+      // Calculate metrics from history
+      let completed = 0, failed = 0, timeout = 0;
+      let totalDuration = 0, durationCount = 0;
+      let inbound = 0, outbound = 0;
+      let withTranscript = 0;
+      const durations: number[] = [];
+      
+      for (const call of calls) {
+        if (call.status === "completed") {
+          completed++;
+          if (call.duration_seconds && call.duration_seconds < 3600) {
+            durations.push(call.duration_seconds);
+            totalDuration += call.duration_seconds;
+            durationCount++;
+          }
+        } else if (call.status === "failed") {
+          failed++;
+        } else if (call.status === "timeout") {
+          timeout++;
+        }
+        
+        if (call.call_type === "inbound") inbound++;
+        else outbound++;
+        
+        if (call.has_transcript) withTranscript++;
+      }
+      
+      durations.sort((a, b) => a - b);
+      const avgDuration = durationCount > 0 ? totalDuration / durationCount : 0;
+      const p50 = durations.length > 0 ? durations[Math.floor(durations.length * 0.5)] : 0;
+      const p95 = durations.length > 0 ? durations[Math.floor(durations.length * 0.95)] : 0;
+      
+      const successRate = calls.length > 0 ? (completed / calls.length) * 100 : 0;
+      
+      return {
+        generated_at: new Date().toISOString(),
+        period: {
+          note: "Based on last 100 calls",
+        },
+        summary: {
+          total_calls: stats.total_calls,
+          success_rate: Math.round(successRate * 10) / 10,
+          avg_duration: Math.round(avgDuration * 10) / 10,
+          active_now: stats.active_calls,
+        },
+        breakdown: {
+          by_status: { completed, failed, timeout, active: stats.active_calls },
+          by_type: { inbound, outbound },
+        },
+        duration: {
+          avg: Math.round(avgDuration * 10) / 10,
+          p50: Math.round(p50 * 10) / 10,
+          p95: Math.round(p95 * 10) / 10,
+        },
+        transcript: {
+          calls_with_transcript: withTranscript,
+          transcript_rate: calls.length > 0 
+            ? Math.round((withTranscript / calls.length) * 1000) / 10 
+            : 0,
+        },
+        bridge: {
+          active_sessions: callSessionMap.size,
+          pending_transcripts: pendingTranscripts.size,
+        },
+      };
+    } catch (err) {
+      return {
+        error: "Failed to construct metrics",
+        details: err instanceof Error ? err.message : String(err),
+        generated_at: new Date().toISOString(),
+      };
+    }
+  }
+
+  /**
+   * Export metrics data in specified format.
+   */
+  async exportMetrics(format: string, days: number): Promise<string> {
+    try {
+      const url = `${this.config.webhookServerUrl}/metrics/export?format=${format}&days=${days}`;
+      const response = await fetch(url, { method: "GET" });
+      
+      if (response.ok) {
+        return await response.text();
+      }
+      
+      // Fallback: construct from history
+      return this.constructExport(format, days);
+    } catch (err) {
+      this.log.warn(`[voice-bridge] Export fetch failed, using fallback: ${err}`);
+      return this.constructExport(format, days);
+    }
+  }
+
+  /**
+   * Construct export from available data.
+   */
+  private async constructExport(format: string, days: number): Promise<string> {
+    try {
+      const historyUrl = `${this.config.webhookServerUrl}/history?limit=500`;
+      const response = await fetch(historyUrl);
+      
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      
+      const calls = await response.json() as Array<Record<string, unknown>>;
+      
+      if (format === "csv") {
+        const headers = ["call_id", "call_type", "caller_number", "callee_number", 
+                        "started_at", "ended_at", "duration_seconds", "status", "has_transcript"];
+        const lines = [headers.join(",")];
+        
+        for (const call of calls) {
+          const values = headers.map(h => {
+            const v = call[h];
+            if (v === null || v === undefined) return "";
+            const s = String(v);
+            return s.includes(",") ? `"${s}"` : s;
+          });
+          lines.push(values.join(","));
+        }
+        
+        return lines.join("\n") + "\n";
+      }
+      
+      return JSON.stringify({
+        exported_at: new Date().toISOString(),
+        period_days: days,
+        call_count: calls.length,
+        calls,
+      }, null, 2);
+    } catch (err) {
+      return JSON.stringify({ error: "Export failed", details: String(err) });
+    }
+  }
+
+  /**
+   * Get health check with metrics indicators.
+   */
+  async getHealthCheck(): Promise<{ 
+    status: string; 
+    timestamp: string; 
+    indicators: Record<string, unknown>;
+    warnings: string[];
+  }> {
+    try {
+      const url = `${this.config.webhookServerUrl}/metrics/health`;
+      const response = await fetch(url, { method: "GET" });
+      
+      if (response.ok) {
+        return await response.json() as {
+          status: string;
+          timestamp: string;
+          indicators: Record<string, unknown>;
+          warnings: string[];
+        };
+      }
+      
+      // Fallback
+      return this.constructHealthCheck();
+    } catch (err) {
+      this.log.warn(`[voice-bridge] Health check failed, using fallback: ${err}`);
+      return this.constructHealthCheck();
+    }
+  }
+
+  /**
+   * Construct health check from available data.
+   */
+  private async constructHealthCheck(): Promise<{
+    status: string;
+    timestamp: string;
+    indicators: Record<string, unknown>;
+    warnings: string[];
+  }> {
+    const warnings: string[] = [];
+    let status = "healthy";
+    
+    try {
+      const statsUrl = `${this.config.webhookServerUrl}/storage/stats`;
+      const response = await fetch(statsUrl);
+      
+      if (!response.ok) {
+        warnings.push("Cannot reach webhook server");
+        status = "degraded";
+      } else {
+        const stats = await response.json() as { 
+          active_calls: number; 
+          total_calls: number;
+        };
+        
+        if (stats.active_calls > 10) {
+          warnings.push(`High active calls: ${stats.active_calls}`);
+        }
+      }
+    } catch (err) {
+      warnings.push(`Webhook server unreachable: ${err}`);
+      status = "degraded";
+    }
+    
+    return {
+      status,
+      timestamp: new Date().toISOString(),
+      indicators: {
+        bridge_active_sessions: callSessionMap.size,
+        bridge_pending_transcripts: pendingTranscripts.size,
+      },
+      warnings,
+    };
+  }
+
+  /**
+   * Get recent failures for debugging.
+   */
+  async getRecentFailures(limit: number): Promise<Array<Record<string, unknown>>> {
+    try {
+      const url = `${this.config.webhookServerUrl}/metrics/failures?limit=${limit}`;
+      const response = await fetch(url, { method: "GET" });
+      
+      if (response.ok) {
+        const data = await response.json() as { failures: Array<Record<string, unknown>> };
+        return data.failures || [];
+      }
+      
+      // Fallback: filter from history
+      return this.constructRecentFailures(limit);
+    } catch (err) {
+      this.log.warn(`[voice-bridge] Failures fetch failed, using fallback: ${err}`);
+      return this.constructRecentFailures(limit);
+    }
+  }
+
+  /**
+   * Construct recent failures from history.
+   */
+  private async constructRecentFailures(limit: number): Promise<Array<Record<string, unknown>>> {
+    try {
+      const historyUrl = `${this.config.webhookServerUrl}/history?limit=100`;
+      const response = await fetch(historyUrl);
+      
+      if (!response.ok) {
+        return [];
+      }
+      
+      const calls = await response.json() as Array<{
+        status: string;
+        [key: string]: unknown;
+      }>;
+      
+      return calls
+        .filter(c => c.status === "failed" || c.status === "timeout")
+        .slice(0, limit);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Get hourly timeseries for charts.
+   */
+  async getHourlyTimeseries(hours: number): Promise<Array<Record<string, unknown>>> {
+    try {
+      const url = `${this.config.webhookServerUrl}/metrics/hourly?hours=${hours}`;
+      const response = await fetch(url, { method: "GET" });
+      
+      if (response.ok) {
+        const data = await response.json() as { timeseries: Array<Record<string, unknown>> };
+        return data.timeseries || [];
+      }
+      
+      return [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Get daily timeseries for trends.
+   */
+  async getDailyTimeseries(days: number): Promise<Array<Record<string, unknown>>> {
+    try {
+      const url = `${this.config.webhookServerUrl}/metrics/daily?days=${days}`;
+      const response = await fetch(url, { method: "GET" });
+      
+      if (response.ok) {
+        const data = await response.json() as { timeseries: Array<Record<string, unknown>> };
+        return data.timeseries || [];
+      }
+      
+      return [];
+    } catch {
+      return [];
     }
   }
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,392 @@
+# Call Observability Guide
+
+Production-ready observability for voice calls. Enables debugging, monitoring, and analytics.
+
+## Quick Start
+
+### Start Metrics Server
+
+```bash
+cd /path/to/openai-voice-skill/scripts
+python metrics_server.py --port 8083
+```
+
+### Access Metrics
+
+```bash
+# Dashboard data (JSON)
+curl http://localhost:8083/metrics/dashboard
+
+# Prometheus metrics
+curl http://localhost:8083/metrics/prometheus
+
+# Health check
+curl http://localhost:8083/metrics/health
+
+# Recent failures
+curl http://localhost:8083/metrics/failures
+```
+
+### Via Session Bridge
+
+If running via the session bridge (port 8082):
+
+```bash
+curl http://localhost:8082/metrics/dashboard
+curl http://localhost:8082/metrics/health
+```
+
+---
+
+## Architecture
+
+```
+┌─────────────────────┐      ┌──────────────────────┐
+│  webhook-server.py  │──────│   call_recording.py  │
+│  (voice handling)   │      │   (call database)    │
+└─────────────────────┘      └──────────┬───────────┘
+                                        │
+                             ┌──────────▼───────────┐
+                             │   call_metrics.py    │
+                             │   (aggregation)      │
+                             └──────────┬───────────┘
+                                        │
+              ┌─────────────────────────┼─────────────────────────┐
+              │                         │                         │
+    ┌─────────▼─────────┐     ┌─────────▼─────────┐     ┌─────────▼─────────┐
+    │  metrics_server   │     │  session-bridge   │     │  CLI (direct)     │
+    │  (port 8083)      │     │  (port 8082)      │     │                   │
+    └───────────────────┘     └───────────────────┘     └───────────────────┘
+```
+
+---
+
+## Endpoints
+
+### `GET /metrics/prometheus`
+
+Prometheus-compatible metrics for monitoring systems.
+
+```
+# HELP voice_calls_total Total number of calls
+# TYPE voice_calls_total counter
+voice_calls_total 142
+
+# HELP voice_calls_success_rate Call success rate percentage
+# TYPE voice_calls_success_rate gauge
+voice_calls_success_rate 94.37
+
+# HELP voice_calls_active Currently active calls
+# TYPE voice_calls_active gauge
+voice_calls_active 2
+
+# HELP voice_call_duration_seconds Call duration statistics
+# TYPE voice_call_duration_seconds summary
+voice_call_duration_seconds{quantile="0.5"} 45.30
+voice_call_duration_seconds{quantile="0.95"} 120.50
+voice_call_duration_seconds{quantile="0.99"} 180.20
+```
+
+### `GET /metrics/dashboard`
+
+Comprehensive dashboard data for visualization.
+
+```json
+{
+  "generated_at": "2026-02-06T10:30:00.000Z",
+  "period": {
+    "start": "2026-02-05T10:30:00.000Z",
+    "end": "2026-02-06T10:30:00.000Z"
+  },
+  "summary": {
+    "total_calls": 142,
+    "total_calls_delta": 15.2,
+    "success_rate": 94.4,
+    "success_rate_delta": 2.1,
+    "avg_duration": 67.3,
+    "avg_duration_delta": -5.2,
+    "active_now": 2
+  },
+  "breakdown": {
+    "by_status": {
+      "completed": 134,
+      "failed": 5,
+      "timeout": 2,
+      "cancelled": 1,
+      "active": 0
+    },
+    "by_type": {
+      "inbound": 45,
+      "outbound": 97
+    },
+    "failure_reasons": {
+      "unknown": 5
+    }
+  },
+  "duration": {
+    "avg": 67.3,
+    "min": 12.1,
+    "max": 245.8,
+    "p50": 55.2,
+    "p95": 145.3,
+    "p99": 210.5,
+    "total_seconds": 9018
+  },
+  "transcript": {
+    "calls_with_transcript": 138,
+    "transcript_rate": 97.2
+  },
+  "timeseries": {
+    "hourly": [...]
+  }
+}
+```
+
+### `GET /metrics/health`
+
+Health check for monitoring systems.
+
+```json
+{
+  "status": "healthy",
+  "timestamp": "2026-02-06T10:30:00.000Z",
+  "indicators": {
+    "calls_last_hour": 12,
+    "success_rate": 100.0,
+    "active_calls": 1,
+    "avg_duration": 45.2
+  },
+  "warnings": []
+}
+```
+
+**Status codes:**
+- `200` - Healthy
+- `503` - Degraded (check `warnings` array)
+
+### `GET /metrics/failures?limit=10`
+
+Recent failed calls for debugging.
+
+```json
+{
+  "failures": [
+    {
+      "call_id": "abc123",
+      "call_type": "outbound",
+      "caller_number": "+14402915517",
+      "callee_number": "+1234567890",
+      "started_at": "2026-02-06T10:15:00",
+      "ended_at": "2026-02-06T10:15:30",
+      "duration_seconds": 30.5,
+      "status": "failed",
+      "failure_reason": "unknown"
+    }
+  ],
+  "count": 1
+}
+```
+
+### `GET /metrics/export?format=json&days=30`
+
+Export call data for analytics.
+
+**Parameters:**
+- `format`: `json` (default) or `csv`
+- `days`: Number of days to export (default: 30)
+
+### `GET /metrics/hourly?hours=24`
+
+Hourly aggregated metrics for time-series charts.
+
+```json
+{
+  "timeseries": [
+    {
+      "hour": "2026-02-06T09:00:00Z",
+      "total": 5,
+      "completed": 5,
+      "failed": 0,
+      "avg_duration": 42.3
+    }
+  ],
+  "hours": 24
+}
+```
+
+### `GET /metrics/daily?days=30`
+
+Daily aggregated metrics for trend analysis.
+
+```json
+{
+  "timeseries": [
+    {
+      "date": "2026-02-05",
+      "total": 45,
+      "completed": 43,
+      "failed": 2,
+      "avg_duration": 58.7,
+      "success_rate": 95.6
+    }
+  ],
+  "days": 30
+}
+```
+
+---
+
+## CLI Usage
+
+Direct access to metrics without HTTP server:
+
+```bash
+cd /path/to/openai-voice-skill/scripts
+
+# Dashboard data
+python call_metrics.py dashboard
+
+# Prometheus format
+python call_metrics.py prometheus
+
+# Health check
+python call_metrics.py health
+
+# Recent failures
+python call_metrics.py failures
+
+# Export to CSV
+python call_metrics.py export-csv --days 30 > calls.csv
+
+# Export to JSON
+python call_metrics.py export-json --days 30 > calls.json
+
+# Hourly timeseries
+python call_metrics.py hourly --hours 48
+
+# Daily timeseries
+python call_metrics.py daily --days 7
+```
+
+---
+
+## Monitoring Integration
+
+### Prometheus
+
+Add to `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'voice-calls'
+    static_configs:
+      - targets: ['localhost:8083']
+    metrics_path: '/metrics/prometheus'
+    scrape_interval: 30s
+```
+
+### Grafana
+
+Use the dashboard endpoint to populate Grafana panels:
+
+```
+# Data source query (JSON API)
+GET http://localhost:8083/metrics/dashboard
+```
+
+### AlertManager
+
+Example alert rules:
+
+```yaml
+groups:
+  - name: voice-calls
+    rules:
+      - alert: VoiceCallSuccessRateLow
+        expr: voice_calls_success_rate < 80
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Voice call success rate below 80%
+      
+      - alert: ZombieCallsDetected
+        expr: voice_calls_active > 10
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: High number of active calls (possible zombies)
+```
+
+---
+
+## Debugging Guide
+
+### Identifying Issues
+
+1. **Check health endpoint first:**
+   ```bash
+   curl http://localhost:8083/metrics/health
+   ```
+
+2. **If degraded, check recent failures:**
+   ```bash
+   curl http://localhost:8083/metrics/failures?limit=5
+   ```
+
+3. **Look for patterns in hourly data:**
+   ```bash
+   curl http://localhost:8083/metrics/hourly?hours=6
+   ```
+
+### Common Issues
+
+| Issue | Indicator | Resolution |
+|-------|-----------|------------|
+| High failure rate | `success_rate < 80%` | Check `/metrics/failures` for patterns |
+| Zombie calls | `active_calls > 10` | Run cleanup: `POST /cleanup-stale-calls` |
+| Missing transcripts | `transcript_rate < 90%` | Check `call_recording.py` logs |
+| Long durations | `p95 > 300s` | Review call types in `/metrics/export` |
+
+### Structured Logging
+
+Enable structured JSON logging for production debugging:
+
+```python
+from call_metrics import metrics_manager
+
+# Emit call event
+metrics_manager.log_call_event(
+    "started",
+    call_id="abc123",
+    call_type="outbound",
+    phone_number="+1234567890"
+)
+
+# Output (JSON):
+# {"timestamp": "2026-02-06T10:30:00.000Z", "level": "INFO", 
+#  "logger": "voice.metrics", "message": "call_started",
+#  "call_id": "abc123", "call_type": "outbound", "phone_number": "+1234567890"}
+```
+
+---
+
+## Performance Considerations
+
+- **Metrics queries are read-only** - no impact on call processing
+- **SQLite database** - suitable for moderate call volume (<1000 calls/day)
+- **Timeseries queries** - aggregated in memory, cache for high-traffic dashboards
+- **Export operations** - can be slow for large date ranges; use pagination
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/call_metrics.py` | Core metrics aggregation |
+| `scripts/metrics_server.py` | HTTP server for metrics |
+| `scripts/call_recording.py` | Call database and lifecycle |
+| `channel-plugin/src/adapters/session-bridge.ts` | Metrics proxy via bridge |
+| `docs/OBSERVABILITY.md` | This documentation |

--- a/scripts/call_metrics.py
+++ b/scripts/call_metrics.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+"""
+Call Metrics and Observability Module
+
+Provides production-ready call metrics, analytics, and monitoring hooks.
+Designed for dashboard integration and debugging.
+
+Features:
+- Aggregate metrics (success rate, duration percentiles, failure reasons)
+- Time-series data for dashboards (hourly/daily buckets)
+- Structured logging for debugging
+- CSV/JSON exports for analytics
+- Real-time call status monitoring
+
+Usage:
+    from call_metrics import metrics_manager
+    
+    # Get dashboard data
+    dashboard = metrics_manager.get_dashboard_data()
+    
+    # Export for analytics
+    csv_data = metrics_manager.export_csv(days=30)
+"""
+
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime, timedelta
+from dataclasses import dataclass, asdict, field
+from typing import Optional, Dict, List, Any, Tuple
+from enum import Enum
+from pathlib import Path
+import statistics
+
+# Import from call_recording for database access
+DATABASE_PATH = Path(os.getenv("DATABASE_PATH", "call_history.db"))
+
+logger = logging.getLogger(__name__)
+
+# Configure structured logging
+class StructuredFormatter(logging.Formatter):
+    """JSON-structured log formatter for production debugging."""
+    
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        
+        # Add extra fields if present
+        if hasattr(record, 'call_id'):
+            log_entry['call_id'] = record.call_id
+        if hasattr(record, 'call_type'):
+            log_entry['call_type'] = record.call_type
+        if hasattr(record, 'duration_seconds'):
+            log_entry['duration_seconds'] = record.duration_seconds
+        if hasattr(record, 'status'):
+            log_entry['status'] = record.status
+        if hasattr(record, 'error_category'):
+            log_entry['error_category'] = record.error_category
+        if hasattr(record, 'phone_number'):
+            log_entry['phone_number'] = record.phone_number
+        if hasattr(record, 'metrics'):
+            log_entry['metrics'] = record.metrics
+            
+        return json.dumps(log_entry)
+
+
+class CallStatus(Enum):
+    """Standardized call status values."""
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    TIMEOUT = "timeout"  # Zombie calls cleaned up
+
+
+class FailureReason(Enum):
+    """Categorized failure reasons for debugging."""
+    TIMEOUT = "timeout"
+    USER_HANGUP = "user_hangup"
+    NETWORK_ERROR = "network_error"
+    API_ERROR = "api_error"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class CallMetrics:
+    """Aggregate call metrics for a time period."""
+    period_start: datetime
+    period_end: datetime
+    total_calls: int = 0
+    completed_calls: int = 0
+    failed_calls: int = 0
+    timeout_calls: int = 0
+    cancelled_calls: int = 0
+    active_calls: int = 0
+    inbound_calls: int = 0
+    outbound_calls: int = 0
+    
+    # Duration metrics (in seconds)
+    total_duration: float = 0.0
+    avg_duration: float = 0.0
+    min_duration: float = 0.0
+    max_duration: float = 0.0
+    p50_duration: float = 0.0
+    p95_duration: float = 0.0
+    p99_duration: float = 0.0
+    
+    # Transcript metrics
+    calls_with_transcript: int = 0
+    transcript_rate: float = 0.0
+    
+    # Success rate
+    success_rate: float = 0.0
+    
+    # Failure breakdown
+    failure_reasons: Dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class HourlyBucket:
+    """Hourly aggregated metrics for time-series charts."""
+    hour: str  # ISO format: "2026-02-06T10:00:00Z"
+    total: int = 0
+    completed: int = 0
+    failed: int = 0
+    avg_duration: float = 0.0
+
+
+@dataclass
+class DailyBucket:
+    """Daily aggregated metrics for trend analysis."""
+    date: str  # ISO format: "2026-02-06"
+    total: int = 0
+    completed: int = 0
+    failed: int = 0
+    avg_duration: float = 0.0
+    success_rate: float = 0.0
+
+
+class CallMetricsManager:
+    """Manages call metrics collection, aggregation, and export."""
+    
+    def __init__(self, db_path: Path = DATABASE_PATH):
+        self.db_path = db_path
+        self._setup_structured_logging()
+    
+    def _setup_structured_logging(self):
+        """Configure structured logging for observability."""
+        metrics_logger = logging.getLogger("voice.metrics")
+        
+        # Check if already configured
+        if not metrics_logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(StructuredFormatter())
+            metrics_logger.addHandler(handler)
+            metrics_logger.setLevel(logging.INFO)
+        
+        self.metrics_logger = metrics_logger
+    
+    def log_call_event(self, event_type: str, call_id: str, **kwargs):
+        """Emit structured log event for call lifecycle."""
+        extra = {"call_id": call_id, **kwargs}
+        record = self.metrics_logger.makeRecord(
+            "voice.metrics", logging.INFO, "", 0, 
+            f"call_{event_type}", (), None
+        )
+        for key, value in extra.items():
+            setattr(record, key, value)
+        self.metrics_logger.handle(record)
+    
+    def get_metrics(self, 
+                    start_time: Optional[datetime] = None,
+                    end_time: Optional[datetime] = None) -> CallMetrics:
+        """
+        Get aggregate call metrics for a time period.
+        
+        Args:
+            start_time: Start of period (default: 24 hours ago)
+            end_time: End of period (default: now)
+        
+        Returns:
+            CallMetrics with all aggregate data
+        """
+        if end_time is None:
+            end_time = datetime.utcnow()
+        if start_time is None:
+            start_time = end_time - timedelta(hours=24)
+        
+        metrics = CallMetrics(period_start=start_time, period_end=end_time)
+        durations: List[float] = []
+        
+        with sqlite3.connect(self.db_path) as conn:
+            # Get all calls in the time period
+            cursor = conn.execute('''
+                SELECT call_id, call_type, started_at, ended_at, 
+                       duration_seconds, status, has_transcript
+                FROM calls
+                WHERE started_at >= ? AND started_at < ?
+                ORDER BY started_at ASC
+            ''', (start_time.isoformat(), end_time.isoformat()))
+            
+            for row in cursor.fetchall():
+                call_id, call_type, started_at, ended_at, duration, status, has_transcript = row
+                
+                metrics.total_calls += 1
+                
+                # Count by type
+                if call_type == "inbound":
+                    metrics.inbound_calls += 1
+                else:
+                    metrics.outbound_calls += 1
+                
+                # Count by status
+                if status == "completed":
+                    metrics.completed_calls += 1
+                    if duration:
+                        durations.append(duration)
+                        metrics.total_duration += duration
+                elif status == "failed":
+                    metrics.failed_calls += 1
+                    reason = self._categorize_failure(call_id)
+                    metrics.failure_reasons[reason] = metrics.failure_reasons.get(reason, 0) + 1
+                elif status == "timeout":
+                    metrics.timeout_calls += 1
+                elif status == "cancelled":
+                    metrics.cancelled_calls += 1
+                elif status == "active":
+                    metrics.active_calls += 1
+                
+                # Transcript metrics
+                if has_transcript:
+                    metrics.calls_with_transcript += 1
+        
+        # Calculate duration statistics
+        if durations:
+            metrics.avg_duration = statistics.mean(durations)
+            metrics.min_duration = min(durations)
+            metrics.max_duration = max(durations)
+            
+            sorted_durations = sorted(durations)
+            n = len(sorted_durations)
+            metrics.p50_duration = sorted_durations[n // 2]
+            metrics.p95_duration = sorted_durations[int(n * 0.95)] if n > 1 else sorted_durations[-1]
+            metrics.p99_duration = sorted_durations[int(n * 0.99)] if n > 1 else sorted_durations[-1]
+        
+        # Calculate rates
+        if metrics.total_calls > 0:
+            metrics.success_rate = metrics.completed_calls / metrics.total_calls * 100
+            metrics.transcript_rate = metrics.calls_with_transcript / metrics.total_calls * 100
+        
+        return metrics
+    
+    def _categorize_failure(self, call_id: str) -> str:
+        """Categorize failure reason from call metadata or heuristics."""
+        # For now, return unknown - can be extended with call metadata
+        # In production, webhook-server.py would log failure reasons
+        return FailureReason.UNKNOWN.value
+    
+    def get_hourly_timeseries(self, hours: int = 24) -> List[HourlyBucket]:
+        """
+        Get hourly metrics for time-series visualization.
+        
+        Args:
+            hours: Number of hours to include (default: 24)
+        
+        Returns:
+            List of HourlyBucket objects
+        """
+        end_time = datetime.utcnow()
+        # Round to current hour
+        end_time = end_time.replace(minute=0, second=0, microsecond=0)
+        start_time = end_time - timedelta(hours=hours)
+        
+        buckets: Dict[str, HourlyBucket] = {}
+        
+        # Initialize all buckets
+        current = start_time
+        while current <= end_time:
+            hour_key = current.strftime("%Y-%m-%dT%H:00:00Z")
+            buckets[hour_key] = HourlyBucket(hour=hour_key)
+            current += timedelta(hours=1)
+        
+        # Fill buckets with data
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute('''
+                SELECT started_at, duration_seconds, status
+                FROM calls
+                WHERE started_at >= ? AND started_at < ?
+            ''', (start_time.isoformat(), end_time.isoformat()))
+            
+            duration_by_hour: Dict[str, List[float]] = {}
+            
+            for row in cursor.fetchall():
+                started_at, duration, status = row
+                dt = datetime.fromisoformat(started_at)
+                hour_key = dt.strftime("%Y-%m-%dT%H:00:00Z")
+                
+                if hour_key in buckets:
+                    buckets[hour_key].total += 1
+                    if status == "completed":
+                        buckets[hour_key].completed += 1
+                        if duration:
+                            if hour_key not in duration_by_hour:
+                                duration_by_hour[hour_key] = []
+                            duration_by_hour[hour_key].append(duration)
+                    elif status in ("failed", "timeout"):
+                        buckets[hour_key].failed += 1
+            
+            # Calculate averages
+            for hour_key, durations in duration_by_hour.items():
+                if durations:
+                    buckets[hour_key].avg_duration = statistics.mean(durations)
+        
+        return [buckets[k] for k in sorted(buckets.keys())]
+    
+    def get_daily_timeseries(self, days: int = 30) -> List[DailyBucket]:
+        """
+        Get daily metrics for trend analysis.
+        
+        Args:
+            days: Number of days to include (default: 30)
+        
+        Returns:
+            List of DailyBucket objects
+        """
+        end_date = datetime.utcnow().date()
+        start_date = end_date - timedelta(days=days - 1)
+        
+        buckets: Dict[str, DailyBucket] = {}
+        
+        # Initialize all buckets
+        current = start_date
+        while current <= end_date:
+            date_key = current.isoformat()
+            buckets[date_key] = DailyBucket(date=date_key)
+            current += timedelta(days=1)
+        
+        # Fill buckets with data
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute('''
+                SELECT started_at, duration_seconds, status
+                FROM calls
+                WHERE date(started_at) >= ? AND date(started_at) <= ?
+            ''', (start_date.isoformat(), end_date.isoformat()))
+            
+            duration_by_day: Dict[str, List[float]] = {}
+            
+            for row in cursor.fetchall():
+                started_at, duration, status = row
+                dt = datetime.fromisoformat(started_at)
+                date_key = dt.date().isoformat()
+                
+                if date_key in buckets:
+                    buckets[date_key].total += 1
+                    if status == "completed":
+                        buckets[date_key].completed += 1
+                        if duration:
+                            if date_key not in duration_by_day:
+                                duration_by_day[date_key] = []
+                            duration_by_day[date_key].append(duration)
+                    elif status in ("failed", "timeout"):
+                        buckets[date_key].failed += 1
+            
+            # Calculate averages and success rates
+            for date_key in buckets:
+                bucket = buckets[date_key]
+                if bucket.total > 0:
+                    bucket.success_rate = bucket.completed / bucket.total * 100
+                if date_key in duration_by_day and duration_by_day[date_key]:
+                    bucket.avg_duration = statistics.mean(duration_by_day[date_key])
+        
+        return [buckets[k] for k in sorted(buckets.keys())]
+    
+    def get_dashboard_data(self) -> Dict[str, Any]:
+        """
+        Get comprehensive dashboard data in a single call.
+        
+        Returns:
+            Dict with all metrics for dashboard rendering
+        """
+        now = datetime.utcnow()
+        
+        # Current metrics (last 24 hours)
+        current_metrics = self.get_metrics(
+            start_time=now - timedelta(hours=24),
+            end_time=now
+        )
+        
+        # Previous period for comparison (24-48 hours ago)
+        prev_metrics = self.get_metrics(
+            start_time=now - timedelta(hours=48),
+            end_time=now - timedelta(hours=24)
+        )
+        
+        # Calculate deltas
+        def calc_delta(current: float, previous: float) -> float:
+            if previous == 0:
+                return 100.0 if current > 0 else 0.0
+            return ((current - previous) / previous) * 100
+        
+        # Get active calls right now
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT COUNT(*) FROM calls WHERE status = 'active'"
+            )
+            active_now = cursor.fetchone()[0]
+        
+        return {
+            "generated_at": now.isoformat() + "Z",
+            "period": {
+                "start": current_metrics.period_start.isoformat() + "Z",
+                "end": current_metrics.period_end.isoformat() + "Z"
+            },
+            "summary": {
+                "total_calls": current_metrics.total_calls,
+                "total_calls_delta": calc_delta(
+                    current_metrics.total_calls, prev_metrics.total_calls
+                ),
+                "success_rate": round(current_metrics.success_rate, 1),
+                "success_rate_delta": calc_delta(
+                    current_metrics.success_rate, prev_metrics.success_rate
+                ),
+                "avg_duration": round(current_metrics.avg_duration, 1),
+                "avg_duration_delta": calc_delta(
+                    current_metrics.avg_duration, prev_metrics.avg_duration
+                ),
+                "active_now": active_now,
+            },
+            "breakdown": {
+                "by_status": {
+                    "completed": current_metrics.completed_calls,
+                    "failed": current_metrics.failed_calls,
+                    "timeout": current_metrics.timeout_calls,
+                    "cancelled": current_metrics.cancelled_calls,
+                    "active": current_metrics.active_calls,
+                },
+                "by_type": {
+                    "inbound": current_metrics.inbound_calls,
+                    "outbound": current_metrics.outbound_calls,
+                },
+                "failure_reasons": current_metrics.failure_reasons,
+            },
+            "duration": {
+                "avg": round(current_metrics.avg_duration, 1),
+                "min": round(current_metrics.min_duration, 1),
+                "max": round(current_metrics.max_duration, 1),
+                "p50": round(current_metrics.p50_duration, 1),
+                "p95": round(current_metrics.p95_duration, 1),
+                "p99": round(current_metrics.p99_duration, 1),
+                "total_seconds": round(current_metrics.total_duration, 0),
+            },
+            "transcript": {
+                "calls_with_transcript": current_metrics.calls_with_transcript,
+                "transcript_rate": round(current_metrics.transcript_rate, 1),
+            },
+            "timeseries": {
+                "hourly": [asdict(b) for b in self.get_hourly_timeseries(24)],
+            },
+        }
+    
+    def get_prometheus_metrics(self) -> str:
+        """
+        Export metrics in Prometheus format.
+        
+        Returns:
+            String in Prometheus exposition format
+        """
+        metrics = self.get_metrics()
+        
+        lines = [
+            "# HELP voice_calls_total Total number of calls",
+            "# TYPE voice_calls_total counter",
+            f"voice_calls_total {metrics.total_calls}",
+            "",
+            "# HELP voice_calls_success_rate Call success rate percentage",
+            "# TYPE voice_calls_success_rate gauge",
+            f"voice_calls_success_rate {metrics.success_rate:.2f}",
+            "",
+            "# HELP voice_calls_active Currently active calls",
+            "# TYPE voice_calls_active gauge",
+            f"voice_calls_active {metrics.active_calls}",
+            "",
+            "# HELP voice_call_duration_seconds Call duration statistics",
+            "# TYPE voice_call_duration_seconds summary",
+            f'voice_call_duration_seconds{{quantile="0.5"}} {metrics.p50_duration:.2f}',
+            f'voice_call_duration_seconds{{quantile="0.95"}} {metrics.p95_duration:.2f}',
+            f'voice_call_duration_seconds{{quantile="0.99"}} {metrics.p99_duration:.2f}',
+            f"voice_call_duration_seconds_sum {metrics.total_duration:.2f}",
+            f"voice_call_duration_seconds_count {metrics.completed_calls}",
+            "",
+            "# HELP voice_calls_by_status Number of calls by status",
+            "# TYPE voice_calls_by_status gauge",
+            f'voice_calls_by_status{{status="completed"}} {metrics.completed_calls}',
+            f'voice_calls_by_status{{status="failed"}} {metrics.failed_calls}',
+            f'voice_calls_by_status{{status="timeout"}} {metrics.timeout_calls}',
+            f'voice_calls_by_status{{status="cancelled"}} {metrics.cancelled_calls}',
+            "",
+            "# HELP voice_calls_by_type Number of calls by type",
+            "# TYPE voice_calls_by_type gauge",
+            f'voice_calls_by_type{{type="inbound"}} {metrics.inbound_calls}',
+            f'voice_calls_by_type{{type="outbound"}} {metrics.outbound_calls}',
+            "",
+            "# HELP voice_transcript_rate Percentage of calls with transcripts",
+            "# TYPE voice_transcript_rate gauge",
+            f"voice_transcript_rate {metrics.transcript_rate:.2f}",
+        ]
+        
+        return "\n".join(lines) + "\n"
+    
+    def export_csv(self, 
+                   days: int = 30,
+                   include_metadata: bool = False) -> str:
+        """
+        Export call data as CSV for analytics.
+        
+        Args:
+            days: Number of days to export
+            include_metadata: Include metadata column (JSON)
+        
+        Returns:
+            CSV string
+        """
+        start_date = datetime.utcnow() - timedelta(days=days)
+        
+        headers = [
+            "call_id", "call_type", "caller_number", "callee_number",
+            "started_at", "ended_at", "duration_seconds", "status",
+            "has_transcript", "has_audio"
+        ]
+        if include_metadata:
+            headers.append("metadata")
+        
+        lines = [",".join(headers)]
+        
+        with sqlite3.connect(self.db_path) as conn:
+            query = '''
+                SELECT call_id, call_type, caller_number, callee_number,
+                       started_at, ended_at, duration_seconds, status,
+                       has_transcript, has_audio
+            '''
+            if include_metadata:
+                query += ", metadata"
+            
+            query += '''
+                FROM calls
+                WHERE started_at >= ?
+                ORDER BY started_at ASC
+            '''
+            
+            cursor = conn.execute(query, (start_date.isoformat(),))
+            
+            for row in cursor.fetchall():
+                values = [str(v) if v is not None else "" for v in row]
+                # Escape commas in values
+                values = [f'"{v}"' if "," in v or '"' in v else v for v in values]
+                lines.append(",".join(values))
+        
+        return "\n".join(lines) + "\n"
+    
+    def export_json(self, days: int = 30) -> str:
+        """
+        Export call data as JSON for analytics.
+        
+        Args:
+            days: Number of days to export
+        
+        Returns:
+            JSON string
+        """
+        start_date = datetime.utcnow() - timedelta(days=days)
+        calls = []
+        
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute('''
+                SELECT call_id, call_type, caller_number, callee_number,
+                       started_at, ended_at, duration_seconds, status,
+                       has_transcript, has_audio, metadata
+                FROM calls
+                WHERE started_at >= ?
+                ORDER BY started_at ASC
+            ''', (start_date.isoformat(),))
+            
+            for row in cursor.fetchall():
+                call = {
+                    "call_id": row[0],
+                    "call_type": row[1],
+                    "caller_number": row[2],
+                    "callee_number": row[3],
+                    "started_at": row[4],
+                    "ended_at": row[5],
+                    "duration_seconds": row[6],
+                    "status": row[7],
+                    "has_transcript": bool(row[8]),
+                    "has_audio": bool(row[9]),
+                }
+                if row[10]:
+                    call["metadata"] = json.loads(row[10])
+                calls.append(call)
+        
+        return json.dumps({
+            "exported_at": datetime.utcnow().isoformat() + "Z",
+            "period_days": days,
+            "call_count": len(calls),
+            "calls": calls
+        }, indent=2)
+    
+    def get_recent_failures(self, limit: int = 10) -> List[Dict[str, Any]]:
+        """
+        Get recent failed calls for debugging.
+        
+        Args:
+            limit: Maximum number of failures to return
+        
+        Returns:
+            List of failed call records with context
+        """
+        failures = []
+        
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute('''
+                SELECT call_id, call_type, caller_number, callee_number,
+                       started_at, ended_at, duration_seconds, status, metadata
+                FROM calls
+                WHERE status IN ('failed', 'timeout')
+                ORDER BY started_at DESC
+                LIMIT ?
+            ''', (limit,))
+            
+            for row in cursor.fetchall():
+                failures.append({
+                    "call_id": row[0],
+                    "call_type": row[1],
+                    "caller_number": row[2],
+                    "callee_number": row[3],
+                    "started_at": row[4],
+                    "ended_at": row[5],
+                    "duration_seconds": row[6],
+                    "status": row[7],
+                    "metadata": json.loads(row[8]) if row[8] else None,
+                    "failure_reason": self._categorize_failure(row[0])
+                })
+        
+        return failures
+    
+    def health_check(self) -> Dict[str, Any]:
+        """
+        Perform health check for monitoring systems.
+        
+        Returns:
+            Health status with key indicators
+        """
+        now = datetime.utcnow()
+        metrics = self.get_metrics(
+            start_time=now - timedelta(hours=1),
+            end_time=now
+        )
+        
+        # Define health thresholds
+        is_healthy = True
+        warnings = []
+        
+        # Check success rate
+        if metrics.total_calls > 0 and metrics.success_rate < 80:
+            warnings.append(f"Low success rate: {metrics.success_rate:.1f}%")
+            is_healthy = False
+        
+        # Check for zombie calls
+        if metrics.active_calls > 10:
+            warnings.append(f"High active calls: {metrics.active_calls}")
+        
+        # Check for recent failures
+        recent_failures = self.get_recent_failures(5)
+        if len(recent_failures) > 3:
+            warnings.append(f"Multiple recent failures: {len(recent_failures)} in last 10")
+        
+        return {
+            "status": "healthy" if is_healthy else "degraded",
+            "timestamp": now.isoformat() + "Z",
+            "indicators": {
+                "calls_last_hour": metrics.total_calls,
+                "success_rate": round(metrics.success_rate, 1),
+                "active_calls": metrics.active_calls,
+                "avg_duration": round(metrics.avg_duration, 1),
+            },
+            "warnings": warnings,
+        }
+
+
+# Global instance
+metrics_manager = CallMetricsManager()
+
+
+# CLI for testing
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Call Metrics CLI")
+    parser.add_argument("command", choices=[
+        "dashboard", "metrics", "prometheus", "export-csv", "export-json",
+        "failures", "health", "hourly", "daily"
+    ])
+    parser.add_argument("--days", type=int, default=30, help="Days for export")
+    parser.add_argument("--hours", type=int, default=24, help="Hours for timeseries")
+    
+    args = parser.parse_args()
+    
+    if args.command == "dashboard":
+        print(json.dumps(metrics_manager.get_dashboard_data(), indent=2))
+    elif args.command == "metrics":
+        metrics = metrics_manager.get_metrics()
+        print(json.dumps(asdict(metrics), indent=2, default=str))
+    elif args.command == "prometheus":
+        print(metrics_manager.get_prometheus_metrics())
+    elif args.command == "export-csv":
+        print(metrics_manager.export_csv(days=args.days))
+    elif args.command == "export-json":
+        print(metrics_manager.export_json(days=args.days))
+    elif args.command == "failures":
+        print(json.dumps(metrics_manager.get_recent_failures(), indent=2))
+    elif args.command == "health":
+        print(json.dumps(metrics_manager.health_check(), indent=2))
+    elif args.command == "hourly":
+        data = [asdict(b) for b in metrics_manager.get_hourly_timeseries(args.hours)]
+        print(json.dumps(data, indent=2))
+    elif args.command == "daily":
+        data = [asdict(b) for b in metrics_manager.get_daily_timeseries(args.days)]
+        print(json.dumps(data, indent=2))

--- a/scripts/metrics_server.py
+++ b/scripts/metrics_server.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Metrics HTTP Server
+
+Exposes call_metrics.py functionality via HTTP endpoints.
+Runs alongside webhook-server.py on a separate port.
+
+Endpoints:
+- GET /metrics/prometheus - Prometheus-format metrics
+- GET /metrics/dashboard - Dashboard JSON data
+- GET /metrics/export - CSV/JSON export
+- GET /metrics/health - Health check
+- GET /metrics/failures - Recent failures
+- GET /metrics/hourly - Hourly timeseries
+- GET /metrics/daily - Daily timeseries
+
+Usage:
+    python metrics_server.py [--port 8083]
+"""
+
+import argparse
+import json
+import logging
+import os
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse, parse_qs
+from dataclasses import asdict
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger("metrics-server")
+
+# Import metrics manager (handle both direct run and module import)
+try:
+    from call_metrics import metrics_manager
+except ImportError:
+    from scripts.call_metrics import metrics_manager
+
+class MetricsRequestHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for metrics endpoints."""
+    
+    def log_message(self, format, *args):
+        """Override to use our logger."""
+        logger.debug(f"{self.address_string()} - {format % args}")
+    
+    def send_json_response(self, data, status_code=200):
+        """Send JSON response."""
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(json.dumps(data, default=str).encode("utf-8"))
+    
+    def send_text_response(self, data, content_type="text/plain", status_code=200):
+        """Send plain text response."""
+        self.send_response(status_code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(data.encode("utf-8"))
+    
+    def do_GET(self):
+        """Handle GET requests."""
+        parsed = urlparse(self.path)
+        path = parsed.path
+        query = parse_qs(parsed.query)
+        
+        try:
+            # Prometheus metrics
+            if path == "/metrics/prometheus" or path == "/metrics":
+                metrics = metrics_manager.get_prometheus_metrics()
+                self.send_text_response(metrics, "text/plain; charset=utf-8")
+                return
+            
+            # Dashboard data
+            if path == "/metrics/dashboard":
+                dashboard = metrics_manager.get_dashboard_data()
+                self.send_json_response(dashboard)
+                return
+            
+            # Export data
+            if path == "/metrics/export":
+                format_type = query.get("format", ["json"])[0]
+                days = int(query.get("days", [30])[0])
+                
+                if format_type == "csv":
+                    data = metrics_manager.export_csv(days=days)
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/csv; charset=utf-8")
+                    self.send_header("Content-Disposition", 
+                                   f'attachment; filename="calls-export.csv"')
+                    self.send_header("Access-Control-Allow-Origin", "*")
+                    self.end_headers()
+                    self.wfile.write(data.encode("utf-8"))
+                else:
+                    data = metrics_manager.export_json(days=days)
+                    self.send_text_response(data, "application/json")
+                return
+            
+            # Health check
+            if path == "/metrics/health":
+                health = metrics_manager.health_check()
+                status_code = 200 if health["status"] == "healthy" else 503
+                self.send_json_response(health, status_code)
+                return
+            
+            # Recent failures
+            if path == "/metrics/failures":
+                limit = int(query.get("limit", [10])[0])
+                failures = metrics_manager.get_recent_failures(limit=limit)
+                self.send_json_response({"failures": failures, "count": len(failures)})
+                return
+            
+            # Hourly timeseries
+            if path == "/metrics/hourly":
+                hours = int(query.get("hours", [24])[0])
+                timeseries = metrics_manager.get_hourly_timeseries(hours=hours)
+                data = [asdict(b) for b in timeseries]
+                self.send_json_response({"timeseries": data, "hours": hours})
+                return
+            
+            # Daily timeseries
+            if path == "/metrics/daily":
+                days = int(query.get("days", [30])[0])
+                timeseries = metrics_manager.get_daily_timeseries(days=days)
+                data = [asdict(b) for b in timeseries]
+                self.send_json_response({"timeseries": data, "days": days})
+                return
+            
+            # Root - show available endpoints
+            if path == "/" or path == "":
+                endpoints = {
+                    "name": "Voice Call Metrics Server",
+                    "version": "1.0.0",
+                    "endpoints": {
+                        "/metrics/prometheus": "Prometheus-format metrics",
+                        "/metrics/dashboard": "Dashboard JSON data",
+                        "/metrics/export?format=json&days=30": "Export data",
+                        "/metrics/health": "Health check",
+                        "/metrics/failures?limit=10": "Recent failures",
+                        "/metrics/hourly?hours=24": "Hourly timeseries",
+                        "/metrics/daily?days=30": "Daily timeseries",
+                    }
+                }
+                self.send_json_response(endpoints)
+                return
+            
+            # 404
+            self.send_json_response({"error": "Not found"}, 404)
+            
+        except Exception as e:
+            logger.exception(f"Error handling request: {e}")
+            self.send_json_response({"error": str(e)}, 500)
+    
+    def do_OPTIONS(self):
+        """Handle CORS preflight."""
+        self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+
+def run_server(port: int = 8083):
+    """Run the metrics HTTP server."""
+    server_address = ("0.0.0.0", port)
+    httpd = HTTPServer(server_address, MetricsRequestHandler)
+    
+    logger.info(f"Starting metrics server on port {port}")
+    logger.info("Endpoints:")
+    logger.info(f"  GET http://localhost:{port}/metrics/prometheus")
+    logger.info(f"  GET http://localhost:{port}/metrics/dashboard")
+    logger.info(f"  GET http://localhost:{port}/metrics/export")
+    logger.info(f"  GET http://localhost:{port}/metrics/health")
+    logger.info(f"  GET http://localhost:{port}/metrics/failures")
+    logger.info(f"  GET http://localhost:{port}/metrics/hourly")
+    logger.info(f"  GET http://localhost:{port}/metrics/daily")
+    
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("Shutting down metrics server")
+        httpd.shutdown()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Voice Call Metrics Server")
+    parser.add_argument("--port", type=int, default=8083, 
+                       help="Port to listen on (default: 8083)")
+    
+    args = parser.parse_args()
+    run_server(port=args.port)

--- a/tests/test_call_metrics.py
+++ b/tests/test_call_metrics.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+Tests for Call Metrics Module
+
+Run with: python -m pytest tests/test_call_metrics.py -v
+"""
+
+import json
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Set up test database path before imports
+TEST_DB = tempfile.mktemp(suffix=".db")
+os.environ["DATABASE_PATH"] = TEST_DB
+
+# Import from scripts module (handle path variations)
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from call_metrics import (
+    CallMetricsManager,
+    CallMetrics,
+    HourlyBucket,
+    DailyBucket,
+    CallStatus,
+    FailureReason,
+    StructuredFormatter,
+)
+
+
+@pytest.fixture
+def test_db():
+    """Create a test database with sample data."""
+    # Initialize the database with the schema from call_recording
+    conn = sqlite3.connect(TEST_DB)
+    
+    # Create tables
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS calls (
+            call_id TEXT PRIMARY KEY,
+            call_type TEXT NOT NULL,
+            caller_number TEXT,
+            callee_number TEXT,
+            started_at TEXT NOT NULL,
+            ended_at TEXT,
+            duration_seconds REAL,
+            status TEXT NOT NULL,
+            recording_path TEXT,
+            transcript_path TEXT,
+            has_audio BOOLEAN DEFAULT FALSE,
+            has_transcript BOOLEAN DEFAULT FALSE,
+            metadata TEXT
+        )
+    ''')
+    
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS transcripts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            call_id TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            speaker TEXT NOT NULL,
+            content TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            metadata TEXT,
+            FOREIGN KEY (call_id) REFERENCES calls (call_id)
+        )
+    ''')
+    
+    # Insert sample calls
+    now = datetime.utcnow()
+    sample_calls = [
+        # Completed calls
+        ("call-001", "outbound", "+14402915517", "+1234567890", 
+         (now - timedelta(hours=2)).isoformat(), now.isoformat(), 120.5, "completed", True),
+        ("call-002", "outbound", "+14402915517", "+1234567891", 
+         (now - timedelta(hours=4)).isoformat(), (now - timedelta(hours=3, minutes=58)).isoformat(), 
+         45.3, "completed", True),
+        ("call-003", "inbound", "+1234567892", "+14402915517", 
+         (now - timedelta(hours=6)).isoformat(), (now - timedelta(hours=5, minutes=55)).isoformat(), 
+         300.0, "completed", False),
+        # Failed call
+        ("call-004", "outbound", "+14402915517", "+1234567893", 
+         (now - timedelta(hours=3)).isoformat(), (now - timedelta(hours=2, minutes=59)).isoformat(), 
+         5.0, "failed", False),
+        # Timeout (zombie cleaned up)
+        ("call-005", "outbound", "+14402915517", "+1234567894", 
+         (now - timedelta(hours=5)).isoformat(), (now - timedelta(hours=1)).isoformat(), 
+         14400.0, "timeout", False),
+        # Active call
+        ("call-006", "outbound", "+14402915517", "+1234567895", 
+         (now - timedelta(minutes=5)).isoformat(), None, None, "active", False),
+    ]
+    
+    for call in sample_calls:
+        conn.execute('''
+            INSERT INTO calls (call_id, call_type, caller_number, callee_number,
+                             started_at, ended_at, duration_seconds, status, has_transcript)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', call)
+    
+    conn.commit()
+    conn.close()
+    
+    yield TEST_DB
+    
+    # Cleanup
+    if os.path.exists(TEST_DB):
+        os.remove(TEST_DB)
+
+
+@pytest.fixture
+def metrics_manager(test_db):
+    """Create metrics manager with test database."""
+    return CallMetricsManager(db_path=Path(test_db))
+
+
+class TestCallMetrics:
+    """Test call metrics aggregation."""
+    
+    def test_get_metrics_total_calls(self, metrics_manager):
+        """Test total call count."""
+        metrics = metrics_manager.get_metrics()
+        assert metrics.total_calls == 6
+    
+    def test_get_metrics_status_breakdown(self, metrics_manager):
+        """Test call status breakdown."""
+        metrics = metrics_manager.get_metrics()
+        assert metrics.completed_calls == 3
+        assert metrics.failed_calls == 1
+        assert metrics.timeout_calls == 1
+        assert metrics.active_calls == 1
+    
+    def test_get_metrics_type_breakdown(self, metrics_manager):
+        """Test call type breakdown."""
+        metrics = metrics_manager.get_metrics()
+        assert metrics.outbound_calls == 5
+        assert metrics.inbound_calls == 1
+    
+    def test_get_metrics_duration_stats(self, metrics_manager):
+        """Test duration statistics."""
+        metrics = metrics_manager.get_metrics()
+        # Only completed calls should be counted for duration
+        assert metrics.avg_duration > 0
+        assert metrics.min_duration > 0
+        assert metrics.max_duration >= metrics.min_duration
+        assert metrics.p50_duration > 0
+    
+    def test_get_metrics_success_rate(self, metrics_manager):
+        """Test success rate calculation."""
+        metrics = metrics_manager.get_metrics()
+        # 3 completed out of 6 total = 50%
+        assert metrics.success_rate == 50.0
+    
+    def test_get_metrics_transcript_rate(self, metrics_manager):
+        """Test transcript rate calculation."""
+        metrics = metrics_manager.get_metrics()
+        # 2 with transcript out of 6 total
+        expected_rate = (2 / 6) * 100
+        assert abs(metrics.transcript_rate - expected_rate) < 0.1
+
+
+class TestTimeseries:
+    """Test timeseries data generation."""
+    
+    def test_hourly_timeseries_length(self, metrics_manager):
+        """Test hourly timeseries returns correct number of buckets."""
+        timeseries = metrics_manager.get_hourly_timeseries(hours=24)
+        # Should have 25 buckets (24 hours + current hour)
+        assert len(timeseries) >= 24
+    
+    def test_hourly_bucket_structure(self, metrics_manager):
+        """Test hourly bucket has correct structure."""
+        timeseries = metrics_manager.get_hourly_timeseries(hours=6)
+        for bucket in timeseries:
+            assert isinstance(bucket, HourlyBucket)
+            assert bucket.hour is not None
+            assert isinstance(bucket.total, int)
+            assert isinstance(bucket.completed, int)
+            assert isinstance(bucket.failed, int)
+    
+    def test_daily_timeseries_length(self, metrics_manager):
+        """Test daily timeseries returns correct number of buckets."""
+        timeseries = metrics_manager.get_daily_timeseries(days=7)
+        assert len(timeseries) == 7
+    
+    def test_daily_bucket_success_rate(self, metrics_manager):
+        """Test daily bucket calculates success rate."""
+        timeseries = metrics_manager.get_daily_timeseries(days=1)
+        # Today's bucket should have our test calls
+        today_bucket = timeseries[-1]
+        if today_bucket.total > 0:
+            assert 0 <= today_bucket.success_rate <= 100
+
+
+class TestDashboardData:
+    """Test dashboard data generation."""
+    
+    def test_dashboard_structure(self, metrics_manager):
+        """Test dashboard data has required structure."""
+        dashboard = metrics_manager.get_dashboard_data()
+        
+        assert "generated_at" in dashboard
+        assert "period" in dashboard
+        assert "summary" in dashboard
+        assert "breakdown" in dashboard
+        assert "duration" in dashboard
+        assert "transcript" in dashboard
+        assert "timeseries" in dashboard
+    
+    def test_dashboard_summary(self, metrics_manager):
+        """Test dashboard summary fields."""
+        dashboard = metrics_manager.get_dashboard_data()
+        summary = dashboard["summary"]
+        
+        assert "total_calls" in summary
+        assert "success_rate" in summary
+        assert "avg_duration" in summary
+        assert "active_now" in summary
+    
+    def test_dashboard_deltas(self, metrics_manager):
+        """Test dashboard includes delta calculations."""
+        dashboard = metrics_manager.get_dashboard_data()
+        summary = dashboard["summary"]
+        
+        assert "total_calls_delta" in summary
+        assert "success_rate_delta" in summary
+        assert "avg_duration_delta" in summary
+
+
+class TestExports:
+    """Test data export functionality."""
+    
+    def test_csv_export_format(self, metrics_manager):
+        """Test CSV export has correct format."""
+        csv_data = metrics_manager.export_csv(days=7)
+        
+        lines = csv_data.strip().split("\n")
+        assert len(lines) >= 1  # At least header
+        
+        # Check header
+        header = lines[0]
+        assert "call_id" in header
+        assert "status" in header
+        assert "duration_seconds" in header
+    
+    def test_csv_export_content(self, metrics_manager):
+        """Test CSV export contains expected data."""
+        csv_data = metrics_manager.export_csv(days=7)
+        
+        lines = csv_data.strip().split("\n")
+        # Should have header + 6 calls
+        assert len(lines) == 7
+    
+    def test_json_export_format(self, metrics_manager):
+        """Test JSON export has correct format."""
+        json_data = metrics_manager.export_json(days=7)
+        
+        data = json.loads(json_data)
+        assert "exported_at" in data
+        assert "period_days" in data
+        assert "call_count" in data
+        assert "calls" in data
+    
+    def test_json_export_content(self, metrics_manager):
+        """Test JSON export contains expected data."""
+        json_data = metrics_manager.export_json(days=7)
+        
+        data = json.loads(json_data)
+        assert data["call_count"] == 6
+
+
+class TestPrometheusMetrics:
+    """Test Prometheus metrics generation."""
+    
+    def test_prometheus_format(self, metrics_manager):
+        """Test Prometheus output format."""
+        prom = metrics_manager.get_prometheus_metrics()
+        
+        # Should contain metric names and values
+        assert "voice_calls_total" in prom
+        assert "voice_calls_success_rate" in prom
+        assert "voice_calls_active" in prom
+        assert "voice_call_duration_seconds" in prom
+    
+    def test_prometheus_types(self, metrics_manager):
+        """Test Prometheus type annotations."""
+        prom = metrics_manager.get_prometheus_metrics()
+        
+        assert "# TYPE voice_calls_total counter" in prom
+        assert "# TYPE voice_calls_success_rate gauge" in prom
+        assert "# TYPE voice_calls_active gauge" in prom
+    
+    def test_prometheus_quantiles(self, metrics_manager):
+        """Test Prometheus quantile values."""
+        prom = metrics_manager.get_prometheus_metrics()
+        
+        assert 'quantile="0.5"' in prom
+        assert 'quantile="0.95"' in prom
+        assert 'quantile="0.99"' in prom
+
+
+class TestHealthCheck:
+    """Test health check functionality."""
+    
+    def test_health_check_structure(self, metrics_manager):
+        """Test health check response structure."""
+        health = metrics_manager.health_check()
+        
+        assert "status" in health
+        assert "timestamp" in health
+        assert "indicators" in health
+        assert "warnings" in health
+    
+    def test_health_check_status(self, metrics_manager):
+        """Test health check returns valid status."""
+        health = metrics_manager.health_check()
+        
+        assert health["status"] in ("healthy", "degraded")
+    
+    def test_health_check_indicators(self, metrics_manager):
+        """Test health check includes indicators."""
+        health = metrics_manager.health_check()
+        indicators = health["indicators"]
+        
+        assert "calls_last_hour" in indicators
+        assert "success_rate" in indicators
+        assert "active_calls" in indicators
+
+
+class TestRecentFailures:
+    """Test recent failures retrieval."""
+    
+    def test_recent_failures_content(self, metrics_manager):
+        """Test recent failures returns failed calls."""
+        failures = metrics_manager.get_recent_failures(limit=10)
+        
+        # Should include our failed and timeout calls
+        statuses = [f["status"] for f in failures]
+        assert "failed" in statuses or "timeout" in statuses
+    
+    def test_recent_failures_limit(self, metrics_manager):
+        """Test recent failures respects limit."""
+        failures = metrics_manager.get_recent_failures(limit=1)
+        
+        assert len(failures) <= 1
+
+
+class TestStructuredLogging:
+    """Test structured logging formatter."""
+    
+    def test_json_format(self):
+        """Test log output is valid JSON."""
+        formatter = StructuredFormatter()
+        
+        import logging
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Test message",
+            args=(),
+            exc_info=None
+        )
+        
+        output = formatter.format(record)
+        data = json.loads(output)
+        
+        assert "timestamp" in data
+        assert "level" in data
+        assert "message" in data
+    
+    def test_extra_fields(self):
+        """Test extra fields are included."""
+        formatter = StructuredFormatter()
+        
+        import logging
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Test message",
+            args=(),
+            exc_info=None
+        )
+        record.call_id = "test-123"
+        record.status = "completed"
+        
+        output = formatter.format(record)
+        data = json.loads(output)
+        
+        assert data["call_id"] == "test-123"
+        assert data["status"] == "completed"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds comprehensive call observability for production debugging and monitoring.

## Changes

### New: `scripts/call_metrics.py`
Core metrics aggregation and analytics module:
- **Aggregate metrics**: success rate, failure rate, duration stats (p50/p95/p99)
- **Time-series**: hourly and daily buckets for dashboard charts
- **Prometheus**: compatible metrics export for monitoring systems
- **Export**: CSV and JSON for analytics pipelines
- **Health check**: with degradation warnings
- **Structured logging**: JSON format for production debugging

### New: `scripts/metrics_server.py`
HTTP server exposing metrics (default port 8083):
| Endpoint | Description |
|----------|-------------|
| `GET /metrics/prometheus` | Prometheus scraping |
| `GET /metrics/dashboard` | Dashboard JSON |
| `GET /metrics/export` | CSV/JSON export |
| `GET /metrics/health` | Health check |
| `GET /metrics/failures` | Recent failures |
| `GET /metrics/hourly` | Hourly timeseries |
| `GET /metrics/daily` | Daily timeseries |

### New: `docs/OBSERVABILITY.md`
Comprehensive documentation:
- Architecture overview
- Endpoint reference with examples
- Prometheus/Grafana integration
- Debugging guide
- CLI usage

### Updated: `session-bridge.ts`
- Adds proxy endpoints for metrics via session bridge (port 8082)
- Fallback construction when Python server unavailable

### New: `tests/test_call_metrics.py`
Full test coverage for the metrics module.

## Usage

```bash
# Start metrics server
python scripts/metrics_server.py --port 8083

# Access dashboard data
curl http://localhost:8083/metrics/dashboard

# Prometheus scraping
curl http://localhost:8083/metrics/prometheus

# Health check
curl http://localhost:8083/metrics/health
```

## Testing

- [x] Python modules compile without errors
- [x] TypeScript compiles without errors
- [ ] QA validation needed

## Closes

Part of Phase 2 observability work (unblocked by #38 fix in PR #39).

---

**Ready for QA review.**