### PR TITLE
feat: Add MCP server for Claude Desktop integration

### DIFF
--- a/MCP_SERVER_PLAN.md
+++ b/MCP_SERVER_PLAN.md
@@ -1,0 +1,183 @@
+# MCP Server Plan — openai-voice-skill
+
+**Created by:** Voice PM (session: voice-pm-cycle-2)
+**Date:** 2026-04-07
+
+---
+
+## Goal
+
+Package the voice skill as an **MCP (Model Context Protocol) server** so users can install it via:
+
+```bash
+claude mcp add openai-voice-skill
+```
+
+This gives the skill native discoverability in Claude Desktop, Claude Code, and any MCP-compatible client — directly complementing our pending PR #791 in anthropics/skills.
+
+---
+
+## What to Build
+
+A Python MCP server (`scripts/mcp_server.py`) that exposes the voice skill's core capabilities as MCP tools.
+
+### MCP Tools to Expose
+
+1. **`make_call`** — Initiate an outbound call to a phone number
+   - Input: `phone_number` (string), `message` (string, optional)
+   - Action: POST to `http://localhost:8080/call`
+   - Returns: call SID, status
+
+2. **`call_status`** — Check status of a call
+   - Input: `call_sid` (string)
+   - Action: GET from Twilio API or local state
+   - Returns: status, duration
+
+3. **`join_google_meet`** — Join a Google Meet via PSTN
+   - Input: `meet_url` (string)
+   - Action: POST to `http://localhost:8080/call/meet`
+   - Returns: call SID, dial-in number used
+
+4. **`get_call_history`** — List recent calls with summaries
+   - Input: `limit` (int, default 5)
+   - Action: read from `~/repos/openai-voice-skill/call_log.json` or memory files
+   - Returns: list of calls with transcript excerpts
+
+---
+
+## Implementation Approach
+
+Use the `mcp` Python package (official Anthropic MCP SDK):
+
+```bash
+pip install mcp
+```
+
+Example server structure (`scripts/mcp_server.py`):
+
+```python
+from mcp.server.fastmcp import FastMCP
+import httpx, json
+
+mcp = FastMCP("openai-voice-skill")
+WEBHOOK_BASE = "http://localhost:8080"
+
+@mcp.tool()
+async def make_call(phone_number: str, message: str = "") -> dict:
+    """Initiate a phone call to the given number."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{WEBHOOK_BASE}/call", json={
+            "to": phone_number,
+            "message": message
+        })
+        return resp.json()
+
+@mcp.tool()
+async def join_google_meet(meet_url: str) -> dict:
+    """Join a Google Meet conference via PSTN dial-in."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{WEBHOOK_BASE}/call/meet", json={
+            "meet_url": meet_url
+        })
+        return resp.json()
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+---
+
+## Files to Create/Modify
+
+| File | Action | Notes |
+|------|--------|-------|
+| `scripts/mcp_server.py` | CREATE | Main MCP server |
+| `scripts/requirements.txt` | MODIFY | Add `mcp>=1.0.0`, `httpx` |
+| `mcp.json` | CREATE | MCP manifest for Claude Desktop |
+| `tests/test_mcp_server.py` | CREATE | Unit tests (mock httpx) |
+| `README.md` | MODIFY | Add MCP installation section |
+
+---
+
+## MCP Manifest (`mcp.json`)
+
+```json
+{
+  "name": "openai-voice-skill",
+  "version": "1.0.0",
+  "description": "Real-time phone calling and Google Meet joining for AI agents",
+  "server": {
+    "command": "python",
+    "args": ["scripts/mcp_server.py"],
+    "env": {}
+  },
+  "tools": [
+    "make_call",
+    "call_status",
+    "join_google_meet",
+    "get_call_history"
+  ]
+}
+```
+
+---
+
+## Acceptance Criteria
+
+1. `python scripts/mcp_server.py` starts without error
+2. MCP server lists 4 tools when queried
+3. `make_call` correctly POSTs to `http://localhost:8080/call`
+4. `join_google_meet` correctly POSTs to `http://localhost:8080/call/meet`
+5. All new tests pass (`pytest tests/test_mcp_server.py`)
+6. Existing 670+ tests still pass (no regressions)
+7. README has installation instructions for Claude Desktop users
+8. PR opened with all changes
+
+---
+
+## GitHub Issue
+
+Create a GitHub issue for tracking: "feat: Add MCP server — voice calling tools for Claude Desktop"
+
+---
+
+## PR Instructions
+
+After implementation:
+1. `git checkout -b feat/mcp-server`
+2. Commit all changes
+3. Push and open PR: `gh pr create --title "feat: Add MCP server for Claude Desktop integration" --body "..."`
+4. PR body should include: what was added, how to test, links to MCP docs
+
+---
+
+## Installation Instructions for README (add these)
+
+```markdown
+## Claude Desktop / MCP Integration
+
+Install as an MCP server in Claude Desktop:
+
+```bash
+# 1. Install the MCP package
+pip install mcp httpx
+
+# 2. Start the voice server (see Setup above)
+python scripts/webhook-server.py
+
+# 3. Add to Claude Desktop's MCP config (~/.claude/mcp.json)
+{
+  "mcpServers": {
+    "openai-voice-skill": {
+      "command": "python",
+      "args": ["/path/to/openai-voice-skill/scripts/mcp_server.py"]
+    }
+  }
+}
+```
+
+Then in Claude Desktop, you can say:
+- "Call +1234567890"
+- "Join this Google Meet: https://meet.google.com/xxx-yyyy-zzz"
+- "What calls did Nia make today?"
+```

--- a/README.md
+++ b/README.md
@@ -420,6 +420,33 @@ curl http://localhost:8082/health
 lsof -i :8082
 ```
 
+## Claude Desktop / MCP Integration
+
+Install as an MCP server in Claude Desktop:
+
+```bash
+# 1. Install the MCP package
+pip install mcp httpx
+
+# 2. Start the voice server (see Setup above)
+python scripts/webhook-server.py
+
+# 3. Add to Claude Desktop's MCP config (~/.claude/mcp.json)
+{
+  "mcpServers": {
+    "openai-voice-skill": {
+      "command": "python",
+      "args": ["/path/to/openai-voice-skill/scripts/mcp_server.py"]
+    }
+  }
+}
+```
+
+Then in Claude Desktop, you can say:
+- "Call +1234567890"
+- "Join this Google Meet: https://meet.google.com/xxx-yyyy-zzz"
+- "What calls did Nia make today?"
+
 ## Limitations
 
 - Real-time responses during calls use OpenAI Realtime API (not OpenClaw's model)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,28 @@
 # Voice Skill Status
 
-**Last Updated:** 2026-04-07 by Voice QA (Google Meet PSTN Auto-Dial — PR #47 merged)
-**Status:** ✅ PR OPEN — anthropics/skills#791 waiting for maintainer review | ✅ SHIPPED — PR #47 Google Meet PSTN Auto-Dial merged to main
+**Last Updated:** 2026-04-07 by Voice Coder (MCP server — PR #49 opened)
+**Status:** ✅ PR OPEN — anthropics/skills#791 waiting for maintainer review | ✅ PR OPEN — nia-agent-cyber/openai-voice-skill#49 MCP server for Claude Desktop | ✅ SHIPPED — PR #47 Google Meet PSTN Auto-Dial merged to main
+
+---
+
+## 🔄 IN REVIEW — MCP Server for Claude Desktop (PR #49, 2026-04-07)
+
+**GitHub Issue:** https://github.com/nia-agent-cyber/openai-voice-skill/issues/48
+**PR:** https://github.com/nia-agent-cyber/openai-voice-skill/pull/49
+**Branch:** feat/mcp-server
+
+### What was built
+- `scripts/mcp_server.py` — FastMCP server with 4 tools: `make_call`, `call_status`, `join_google_meet`, `get_call_history`
+- `mcp.json` — MCP manifest for `claude mcp add openai-voice-skill`
+- `scripts/requirements.txt` — added `mcp>=1.0.0`
+- `tests/test_mcp_server.py` — 15 unit tests, all httpx mocked
+- `README.md` — Claude Desktop / MCP installation section
+
+### Test results
+762 passed, 7 warnings — no regressions.
+
+### Next step for QA
+Review PR #49, run `pytest tests/test_mcp_server.py -v`, approve if clean.
 
 ---
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,16 @@
+{
+  "name": "openai-voice-skill",
+  "version": "1.0.0",
+  "description": "Real-time phone calling and Google Meet joining for AI agents",
+  "server": {
+    "command": "python",
+    "args": ["scripts/mcp_server.py"],
+    "env": {}
+  },
+  "tools": [
+    "make_call",
+    "call_status",
+    "join_google_meet",
+    "get_call_history"
+  ]
+}

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -1,0 +1,144 @@
+"""
+mcp_server.py — MCP server for openai-voice-skill.
+
+Exposes voice skill capabilities as MCP tools for Claude Desktop and
+any MCP-compatible client.
+
+Usage:
+    python scripts/mcp_server.py
+
+Then add to ~/.claude/mcp.json:
+    {
+      "mcpServers": {
+        "openai-voice-skill": {
+          "command": "python",
+          "args": ["/path/to/openai-voice-skill/scripts/mcp_server.py"]
+        }
+      }
+    }
+"""
+
+import json
+import os
+from pathlib import Path
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("openai-voice-skill")
+
+WEBHOOK_BASE = os.environ.get("VOICE_WEBHOOK_BASE", "http://localhost:8080")
+CALL_LOG_PATH = Path(os.environ.get(
+    "VOICE_CALL_LOG",
+    Path.home() / "repos" / "openai-voice-skill" / "call_log.json"
+))
+MEMORY_DIR = Path(os.environ.get(
+    "VOICE_MEMORY_DIR",
+    Path.home() / ".openclaw" / "workspace" / "memory"
+))
+
+
+@mcp.tool()
+async def make_call(phone_number: str, message: str = "") -> dict:
+    """Initiate an outbound phone call to the given number.
+
+    Args:
+        phone_number: E.164 phone number to call (e.g. +12025551234)
+        message: Optional spoken message or instruction for the call
+
+    Returns:
+        dict with call_sid and status from the voice server
+    """
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{WEBHOOK_BASE}/call",
+            json={"to": phone_number, "message": message},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+@mcp.tool()
+async def call_status(call_sid: str) -> dict:
+    """Check the status of a call by its SID.
+
+    Args:
+        call_sid: Twilio call SID (e.g. CAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
+
+    Returns:
+        dict with status and duration fields
+    """
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            f"{WEBHOOK_BASE}/call/{call_sid}/status",
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+@mcp.tool()
+async def join_google_meet(meet_url: str) -> dict:
+    """Join a Google Meet conference via PSTN dial-in.
+
+    Extracts the dial-in number and PIN from the Meet page, then
+    initiates an outbound Twilio call that bridges into the meeting.
+
+    Args:
+        meet_url: Google Meet URL (e.g. https://meet.google.com/abc-defg-hij)
+
+    Returns:
+        dict with call_sid and dial_in_number used
+    """
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{WEBHOOK_BASE}/call/meet",
+            json={"meet_url": meet_url},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+@mcp.tool()
+async def get_call_history(limit: int = 5) -> list:
+    """List recent calls with summaries and transcript excerpts.
+
+    Reads from call_log.json (if present) or recent memory files.
+
+    Args:
+        limit: Maximum number of calls to return (default 5)
+
+    Returns:
+        List of call records, most recent first
+    """
+    calls = []
+
+    # Try call_log.json first
+    if CALL_LOG_PATH.exists():
+        try:
+            data = json.loads(CALL_LOG_PATH.read_text())
+            if isinstance(data, list):
+                calls = data
+            elif isinstance(data, dict) and "calls" in data:
+                calls = data["calls"]
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Fall back to memory files if no log found
+    if not calls and MEMORY_DIR.exists():
+        memory_files = sorted(
+            MEMORY_DIR.glob("*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        for mf in memory_files[:limit]:
+            try:
+                entry = json.loads(mf.read_text())
+                calls.append(entry)
+            except (json.JSONDecodeError, OSError):
+                continue
+
+    return calls[:limit]
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -7,3 +7,4 @@ twilio>=8.0.0
 aiofiles>=23.0.0
 websockets>=12.0
 cryptography>=41.0.0
+mcp>=1.0.0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,255 @@
+"""
+Tests for scripts/mcp_server.py — MCP tool functions.
+
+All httpx network calls are mocked so no live server is required.
+
+Run with:
+    python3 -m pytest tests/test_mcp_server.py -v
+"""
+
+import asyncio
+import json
+import sys
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ─── Path setup ──────────────────────────────────────────────────────────────
+
+_SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+sys.path.insert(0, _SCRIPTS_DIR)
+
+
+# ─── Helper ──────────────────────────────────────────────────────────────────
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+def _mock_response(payload: dict, status_code: int = 200):
+    """Return a mock httpx.Response-like object."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _mock_async_client(response):
+    """Return a context-manager mock for httpx.AsyncClient."""
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.post = AsyncMock(return_value=response)
+    client.get = AsyncMock(return_value=response)
+    return client
+
+
+# ─── Import mcp_server (stub out mcp if not installed) ───────────────────────
+
+# Inject stubs into sys.modules BEFORE importing mcp_server so the module
+# loads cleanly even when the `mcp` package is not installed in the venv.
+# Using setdefault means: if `mcp` IS installed, the real package is used.
+_fake_mcp_pkg = MagicMock()
+_fake_fastmcp_cls = MagicMock()
+_fake_fastmcp_instance = MagicMock()
+_fake_fastmcp_cls.return_value = _fake_fastmcp_instance
+# tool() decorator must return the original function unchanged
+_fake_fastmcp_instance.tool = lambda: (lambda fn: fn)
+_fake_mcp_pkg.server.fastmcp.FastMCP = _fake_fastmcp_cls
+
+sys.modules.setdefault("mcp", _fake_mcp_pkg)
+sys.modules.setdefault("mcp.server", _fake_mcp_pkg.server)
+sys.modules.setdefault("mcp.server.fastmcp", _fake_mcp_pkg.server.fastmcp)
+
+import mcp_server as ms
+
+
+# ─── make_call ────────────────────────────────────────────────────────────────
+
+class TestMakeCall:
+
+    def test_make_call_success(self):
+        payload = {"call_sid": "CA123", "status": "queued"}
+        mock_client = _mock_async_client(_mock_response(payload))
+
+        with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+            result = run(ms.make_call("+12025551234", "Hello world"))
+
+        assert result == payload
+        mock_client.post.assert_awaited_once()
+        call_args = mock_client.post.call_args
+        assert "/call" in call_args[0][0]
+        assert call_args[1]["json"]["to"] == "+12025551234"
+        assert call_args[1]["json"]["message"] == "Hello world"
+
+    def test_make_call_no_message(self):
+        payload = {"call_sid": "CA456", "status": "queued"}
+        mock_client = _mock_async_client(_mock_response(payload))
+
+        with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+            result = run(ms.make_call("+19995550000"))
+
+        assert result["call_sid"] == "CA456"
+        posted = mock_client.post.call_args[1]["json"]
+        assert posted["message"] == ""
+
+    def test_make_call_http_error_propagates(self):
+        resp = _mock_response({}, status_code=500)
+        resp.raise_for_status.side_effect = Exception("Server error")
+        mock_client = _mock_async_client(resp)
+
+        with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(Exception, match="Server error"):
+                run(ms.make_call("+12025551234"))
+
+    def test_make_call_uses_webhook_base(self):
+        payload = {"call_sid": "CA789", "status": "queued"}
+        mock_client = _mock_async_client(_mock_response(payload))
+
+        with patch("mcp_server.WEBHOOK_BASE", "http://example.com:9999"):
+            with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+                run(ms.make_call("+10000000000"))
+
+        url = mock_client.post.call_args[0][0]
+        assert url.startswith("http://example.com:9999")
+
+
+# ─── call_status ──────────────────────────────────────────────────────────────
+
+class TestCallStatus:
+
+    def test_call_status_success(self):
+        payload = {"status": "in-progress", "duration": "42"}
+        mock_client = _mock_async_client(_mock_response(payload))
+
+        with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+            result = run(ms.call_status("CA123"))
+
+        assert result["status"] == "in-progress"
+        mock_client.get.assert_awaited_once()
+        url = mock_client.get.call_args[0][0]
+        assert "CA123" in url
+
+    def test_call_status_not_found_propagates(self):
+        resp = _mock_response({}, status_code=404)
+        resp.raise_for_status.side_effect = Exception("Not found")
+        mock_client = _mock_async_client(resp)
+        mock_client.get = AsyncMock(return_value=resp)
+
+        with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(Exception, match="Not found"):
+                run(ms.call_status("CA_MISSING"))
+
+
+# ─── join_google_meet ─────────────────────────────────────────────────────────
+
+class TestJoinGoogleMeet:
+
+    def test_join_google_meet_success(self):
+        payload = {"call_sid": "CAabc", "dial_in_number": "+18005551234"}
+        mock_client = _mock_async_client(_mock_response(payload))
+
+        with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+            result = run(ms.join_google_meet("https://meet.google.com/abc-defg-hij"))
+
+        assert result == payload
+        posted = mock_client.post.call_args[1]["json"]
+        assert posted["meet_url"] == "https://meet.google.com/abc-defg-hij"
+
+    def test_join_google_meet_posts_to_correct_endpoint(self):
+        payload = {"call_sid": "CAdef", "dial_in_number": "+18005559999"}
+        mock_client = _mock_async_client(_mock_response(payload))
+
+        with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+            run(ms.join_google_meet("https://meet.google.com/xyz-abcd-efg"))
+
+        url = mock_client.post.call_args[0][0]
+        assert url.endswith("/call/meet")
+
+    def test_join_google_meet_error_propagates(self):
+        resp = _mock_response({}, status_code=422)
+        resp.raise_for_status.side_effect = Exception("Unprocessable")
+        mock_client = _mock_async_client(resp)
+
+        with patch("mcp_server.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(Exception, match="Unprocessable"):
+                run(ms.join_google_meet("not-a-meet-url"))
+
+
+# ─── get_call_history ─────────────────────────────────────────────────────────
+
+class TestGetCallHistory:
+
+    def test_get_call_history_from_call_log_list(self, tmp_path):
+        call_log = tmp_path / "call_log.json"
+        records = [{"call_sid": f"CA{i}", "status": "completed"} for i in range(10)]
+        call_log.write_text(json.dumps(records))
+
+        with patch("mcp_server.CALL_LOG_PATH", call_log):
+            result = run(ms.get_call_history(limit=3))
+
+        assert len(result) == 3
+        assert result[0]["call_sid"] == "CA0"
+
+    def test_get_call_history_from_call_log_dict(self, tmp_path):
+        call_log = tmp_path / "call_log.json"
+        records = [{"call_sid": "CA99", "status": "completed"}]
+        call_log.write_text(json.dumps({"calls": records}))
+
+        with patch("mcp_server.CALL_LOG_PATH", call_log):
+            result = run(ms.get_call_history())
+
+        assert result[0]["call_sid"] == "CA99"
+
+    def test_get_call_history_falls_back_to_memory_files(self, tmp_path):
+        # call_log does not exist
+        fake_log = tmp_path / "nonexistent.json"
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+
+        for i in range(3):
+            f = memory_dir / f"call_{i}.json"
+            f.write_text(json.dumps({"call_sid": f"MEM{i}"}))
+
+        with patch("mcp_server.CALL_LOG_PATH", fake_log):
+            with patch("mcp_server.MEMORY_DIR", memory_dir):
+                result = run(ms.get_call_history(limit=2))
+
+        assert len(result) == 2
+
+    def test_get_call_history_empty_when_no_sources(self, tmp_path):
+        fake_log = tmp_path / "nonexistent.json"
+        fake_memory = tmp_path / "no_memory"
+
+        with patch("mcp_server.CALL_LOG_PATH", fake_log):
+            with patch("mcp_server.MEMORY_DIR", fake_memory):
+                result = run(ms.get_call_history())
+
+        assert result == []
+
+    def test_get_call_history_handles_malformed_log(self, tmp_path):
+        call_log = tmp_path / "call_log.json"
+        call_log.write_text("not valid json{{{")
+        fake_memory = tmp_path / "no_memory"
+
+        with patch("mcp_server.CALL_LOG_PATH", call_log):
+            with patch("mcp_server.MEMORY_DIR", fake_memory):
+                result = run(ms.get_call_history())
+
+        assert result == []
+
+    def test_get_call_history_default_limit_is_5(self, tmp_path):
+        call_log = tmp_path / "call_log.json"
+        records = [{"call_sid": f"CA{i}"} for i in range(20)]
+        call_log.write_text(json.dumps(records))
+
+        with patch("mcp_server.CALL_LOG_PATH", call_log):
+            result = run(ms.get_call_history())
+
+        assert len(result) == 5


### PR DESCRIPTION
## Summary

Closes #48.

- **`scripts/mcp_server.py`** — FastMCP server exposing 4 tools: `make_call`, `call_status`, `join_google_meet`, `get_call_history`
- **`mcp.json`** — MCP manifest for one-command install via `claude mcp add`
- **`scripts/requirements.txt`** — adds `mcp>=1.0.0` (httpx was already there)
- **`tests/test_mcp_server.py`** — 15 unit tests, all httpx calls mocked
- **`README.md`** — new "Claude Desktop / MCP Integration" section

## How to test

```bash
# Install deps
pip install mcp httpx

# Run new unit tests
pytest tests/test_mcp_server.py -v

# Start server manually (needs webhook-server.py running)
python scripts/mcp_server.py

# Add to Claude Desktop (~/.claude/mcp.json)
{
  "mcpServers": {
    "openai-voice-skill": {
      "command": "python",
      "args": ["/path/to/openai-voice-skill/scripts/mcp_server.py"]
    }
  }
}
```

## Test results

762 passed, 7 warnings — no regressions vs prior 670+ baseline.

## MCP docs

- https://modelcontextprotocol.io/quickstart/server
- https://docs.anthropic.com/en/docs/claude-code/mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)